### PR TITLE
Add opt-in update notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ const provider = new BookmarksContentProvider();
 const viewer = new WhatsNewManager(context)
     .registerContentProvider("alefragnani", "bookmarks", provider)
     .setUpdateKind("major") // optional, defaults to "minor"
+    .setUpdateDisplayKind("notification") // optional, defaults to "page"
+    .setUpdateNotificationDetailMessage("Click to see the latest improvements.") // optional, defaults to empty
     .registerSocialMediaProvider(new BookmarksSocialMediaProvider())
     .registerSponsorProvider(new BookmarksSponsorProvider());
 
@@ -131,6 +133,12 @@ It follows [SEMVER - Semantic Versioning](https://www.semver.org) to detect **Ma
 
 By default the **What's New** page is displayed for **Major** and **Minor** updates, while **Patch** updates are silent. If you want the page to be displayed only for **Major** updates, use `setUpdateKind("major")` while building `WhatsNewManager`.
 
+### Notification option
+
+By default qualifying updates open the **What's New** page right away. If you prefer to notify the user first and let them decide whether to open the page, use `setUpdateDisplayKind("notification")` while building `WhatsNewManager`. The notification includes a `See What's New` action that opens the webview on demand.
+
+If you want to append extra text after the version number in the notification message, use `setUpdateNotificationDetailMessage("Click to see the latest improvements.")`.
+
 ### Template Based
 
 I don't have to deal with HTML or CSS on my extensions anymore. I just have to _provide_ the relevant information and the HTML page is automatically generated/updated.
@@ -142,3 +150,4 @@ The idea came from the [GitLens extension](https://marketplace.visualstudio.com/
 # License
 
 [MIT](LICENSE.md) &copy; Alessandro Fragnani
+

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -10,6 +10,7 @@ import { ContentProvider, SocialMediaProvider, SponsorProvider } from "./Content
 import { WhatsNewPageBuilder } from "./PageBuilder";
 
 export type UpdateKind = "major" | "minor";
+export type UpdateDisplayKind = "page" | "notification";
 
 export class WhatsNewManager {
 
@@ -24,6 +25,8 @@ export class WhatsNewManager {
     private versionKey!: string;
     private shownKey!: string;
     private updateKind: UpdateKind = "minor";
+    private updateDisplayKind: UpdateDisplayKind = "page";
+    private updateNotificationDetailMessage = "";
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -61,6 +64,16 @@ export class WhatsNewManager {
 
     public setUpdateKind(kind: UpdateKind): WhatsNewManager {
         this.updateKind = kind;
+        return this;
+    }
+
+    public setUpdateDisplayKind(kind: UpdateDisplayKind): WhatsNewManager {
+        this.updateDisplayKind = kind;
+        return this;
+    }
+
+    public setUpdateNotificationDetailMessage(message: string): WhatsNewManager {
+        this.updateNotificationDetailMessage = message;
         return this;
     }
 
@@ -111,7 +124,7 @@ export class WhatsNewManager {
             return;
         }
 
-        await this.showPageInFocusedWindowOnly(currentVersion);
+        await this.showUpdateInFocusedWindowOnly(currentVersion);
     }
 
     public async showPageIfCurrentVersionIsGreaterThanPrevisouVersion(currentVersion: string, previousVersion: string | undefined) {
@@ -133,24 +146,24 @@ export class WhatsNewManager {
             return;
         }
 
-        await this.showPageInFocusedWindowOnly(currentVersion);
+        await this.showUpdateInFocusedWindowOnly(currentVersion);
     }
 
-    private async showPageInFocusedWindowOnly(currentVersion: string): Promise<void> {
-        // Another window already showed the Webview for this version
+    private async showUpdateInFocusedWindowOnly(currentVersion: string): Promise<void> {
+        // Another window already showed the update message for this version
         if (this.context.globalState.get<string>(this.shownKey) === currentVersion) {
             return;
         }
 
         if (vscode.window.state.focused) {
-            await this.showPageAndMarkShown(currentVersion);
+            await this.showUpdateAndMarkShown(currentVersion);
         } else {
             // Defer until this window gains focus; guard against another window showing first
             const disposable = vscode.window.onDidChangeWindowState(state => {
                 if (state.focused) {
                     disposable.dispose();
                     if (this.context.globalState.get<string>(this.shownKey) !== currentVersion) {
-                        this.showPageAndMarkShown(currentVersion).catch(() => { /* ignore */ });
+                        void this.showUpdateAndMarkShown(currentVersion);
                     }
                 }
             });
@@ -158,9 +171,34 @@ export class WhatsNewManager {
         }
     }
 
-    private async showPageAndMarkShown(currentVersion: string): Promise<void> {
-        await this.showPage();
+    private async showUpdateAndMarkShown(currentVersion: string): Promise<void> {
+        await this.showUpdate();
         await this.context.globalState.update(this.shownKey, currentVersion);
+    }
+
+    private async showUpdate(): Promise<void> {
+        if (this.updateDisplayKind === "notification") {
+            await this.showUpdateNotification();
+            return;
+        }
+
+        await this.showPage();
+    }
+
+    private async showUpdateNotification(): Promise<void> {
+        const extensionDisplayName = this.extension.packageJSON.displayName ?? this.extensionName;
+        const showWhatsNewLabel = "See What's New";
+        const detailMessage = this.updateNotificationDetailMessage
+            ? ` ${this.updateNotificationDetailMessage}`
+            : "";
+        const selection = await vscode.window.showInformationMessage(
+            `${extensionDisplayName} was updated to version ${this.extension.packageJSON.version}.${detailMessage}`,
+            showWhatsNewLabel
+        );
+
+        if (selection === showWhatsNewLabel) {
+            await this.showPage();
+        }
     }
 
     private async getWebviewContentLocal(webview: Webview, htmlFile: Uri, cssUrl: Uri, logoUrl: Uri): Promise<string> {
@@ -188,3 +226,5 @@ export class WhatsNewManager {
         return html;
     }
 }
+
+


### PR DESCRIPTION
## Summary
- add an opt-in notification mode for update announcements
- allow a custom detail phrase to be appended to the notification text
- document the new builder options in the README

Closes #45